### PR TITLE
Allow IOB1

### DIFF
--- a/conll03_nel_eval/data.py
+++ b/conll03_nel_eval/data.py
@@ -285,9 +285,11 @@ class Reader(Dialected):
                                 m = None
                             sentence.append(Token(j, j+1, token))
                         elif m is not None and iob == 'I':
+                            # mid-mention
                             m.texts.append(token)
                             m.end += 1
                         elif iob in 'IB':
+                            # transitioning from O or I to B, or from O to I -> begin mention
                             if m is not None:
                                 sentence.append(m)
                                 m = None

--- a/conll03_nel_eval/data.py
+++ b/conll03_nel_eval/data.py
@@ -281,10 +281,11 @@ class Reader(Dialected):
                             raise e
                         if iob is None or iob == 'O':
                             if m is not None:
+                                # leaving mention
                                 sentence.append(m)
                                 m = None
                             sentence.append(Token(j, j+1, token))
-                        elif m is not None and iob == 'I':
+                        elif iob == 'I' and m is not None and m.link == link:
                             # mid-mention
                             m.texts.append(token)
                             m.end += 1

--- a/conll03_nel_eval/data.py
+++ b/conll03_nel_eval/data.py
@@ -284,15 +284,14 @@ class Reader(Dialected):
                                 sentence.append(m)
                                 m = None
                             sentence.append(Token(j, j+1, token))
-                        elif iob == 'B':
+                        elif m is not None and iob == 'I':
+                            m.texts.append(token)
+                            m.end += 1
+                        elif iob in 'IB':
                             if m is not None:
                                 sentence.append(m)
                                 m = None
                             m = Mention(j, j+1, name, [token], link=link, score=score)
-                        elif iob == 'I':
-                            assert m is not None
-                            m.texts.append(token)
-                            m.end += 1
                         else:
                             assert False, 'Unexpected IOB case "{}"'.format(iob)
                         i, l = lines.next()


### PR DESCRIPTION
Two different IOB conventions are in use: use `B` for all mention starts; or use only for abutting mentions of same label (which would be rare in NEL). AFAIK, the latter was used in CoNLL 03. We currently support the former. This patch allows for either.
